### PR TITLE
Added avgbitrate. avgfps stats

### DIFF
--- a/fftools/ffmpeg.c
+++ b/fftools/ffmpeg.c
@@ -1765,7 +1765,7 @@ static void print_report(int is_last_report, int64_t timer_start, int64_t cur_ti
 #if 1
     tr = output_files[0]->bitrate_reset_time ? (cur_time-output_files[0]->bitrate_reset_time) / 1000000.0 : t;
     reset_size = total_size - output_files[0]->reset_size;
-    cur_bitrate = tr>1 && reset_size >= 0 ? reset_size * 8 / tr / 1000.0 : -1;
+    cur_bitrate = tr > 1 && reset_size >= 0 ? reset_size * 8 / tr / 1000.0 : -1;
 #endif
 /*End Proximie*/
 

--- a/fftools/ffmpeg.h
+++ b/fftools/ffmpeg.h
@@ -469,6 +469,11 @@ typedef struct OutputStream {
     AVRational mux_timebase;
     AVRational enc_timebase;
 
+    /*Proximie*/
+    int64_t fps_reset_time; /* time fps was reset */
+    int total_frames;       /* count of frames since stream start vs frame_number that gets reset with variable frame rate changes */
+    /*End Proximie*/
+
     AVBSFContext            *bsf_ctx;
 
     AVCodecContext *enc_ctx;
@@ -579,6 +584,11 @@ typedef struct OutputFile {
     int64_t recording_time;  ///< desired length of the resulting file in microseconds == AV_TIME_BASE units
     int64_t start_time;      ///< start time in microseconds == AV_TIME_BASE units
     uint64_t limit_filesize; /* filesize limit expressed in bytes */
+
+    /*Proximie*/
+    int64_t bitrate_reset_time; /* time bitrate was reset */
+    int64_t reset_size;              /* file size at bitrate reset */
+    /*End Proximie*/
 
     int shortest;
 


### PR DESCRIPTION
- Added avgbitrate/avgfps stats which now show average bitrate/fps since start of streaming.
- Fixed fps/bitrate stats to now show current fps/bitrate since last fps or bitrate change.
- the log now looks as:
frame= 1099 **avgfps= 16 fps= 14** q=0.0 size=   10221kB time=00:01:07.71 **avgbitrate=1236.6kbits/s bitrate=1018.2kbits/s** dup...