### PR TITLE
Fix stats display before 1s of stats is collected

### DIFF
--- a/fftools/ffmpeg.c
+++ b/fftools/ffmpeg.c
@@ -1766,6 +1766,11 @@ static void print_report(int is_last_report, int64_t timer_start, int64_t cur_ti
     tr = output_files[0]->bitrate_reset_time ? (cur_time-output_files[0]->bitrate_reset_time) / 1000000.0 : t;
     reset_size = total_size - output_files[0]->reset_size;
     cur_bitrate = tr > 1 && reset_size >= 0 ? reset_size * 8 / tr / 1000.0 : -1;
+    if(cur_bitrate > 0.0) {
+        output_files[0]->prev_bitrate = cur_bitrate;
+    } else {
+        cur_bitrate = output_files[0]->prev_bitrate;
+    }
 #endif
 /*End Proximie*/
 
@@ -1793,8 +1798,13 @@ static void print_report(int is_last_report, int64_t timer_start, int64_t cur_ti
             frame_number = ost->total_frames;
             fps = t > 1 ? frame_number / t : 0;
             cur_fps = tr > 1 ? ost->frame_number / tr : -1;
+            if(cur_fps > 0.0) {
+                ost->prev_fps = cur_fps;
+            } else {
+                cur_fps = ost->prev_fps;
+            }
             av_bprintf(&buf, "frame=%5d avgfps=%3.*f fps=%3.*f q=%3.1f ",
-                     frame_number, fps < 9.95, fps, cur_fps>0.0?cur_fps < 9.95:fps < 9.95, cur_fps>0.0?cur_fps:fps, q);
+                     frame_number, fps < 9.95, fps, cur_fps < 9.95, cur_fps, q);
 #else
             frame_number = ost->frame_number;
             fps = t > 1 ? frame_number / t : 0;
@@ -1896,7 +1906,7 @@ static void print_report(int is_last_report, int64_t timer_start, int64_t cur_ti
     }else{
 /*Proximie*/
 #if 1
-        av_bprintf(&buf, "avgbitrate=%6.1fkbits/s bitrate=%6.1fkbits/s", bitrate, cur_bitrate>0.0?cur_bitrate:bitrate);
+        av_bprintf(&buf, "avgbitrate=%6.1fkbits/s bitrate=%6.1fkbits/s", bitrate, cur_bitrate);
 #else
         av_bprintf(&buf, "bitrate=%6.1fkbits/s", bitrate);
 #endif

--- a/fftools/ffmpeg.h
+++ b/fftools/ffmpeg.h
@@ -472,6 +472,7 @@ typedef struct OutputStream {
     /*Proximie*/
     int64_t fps_reset_time; /* time fps was reset */
     int total_frames;       /* count of frames since stream start vs frame_number that gets reset with variable frame rate changes */
+    float prev_fps;         /* last valid fps value */
     /*End Proximie*/
 
     AVBSFContext            *bsf_ctx;
@@ -587,7 +588,8 @@ typedef struct OutputFile {
 
     /*Proximie*/
     int64_t bitrate_reset_time; /* time bitrate was reset */
-    int64_t reset_size;              /* file size at bitrate reset */
+    int64_t reset_size;         /* file size at bitrate reset */
+    double prev_bitrate;        /* last valid bitrate value */  
     /*End Proximie*/
 
     int shortest;


### PR DESCRIPTION
During first sec after fps/bitrate changes was showing avg values, but realized this will result in large graph jumps when displayed. This fixes it by re-using previous fps/bitrate stat value for the first second before minimum stats collection period has elapsed.