### PR TITLE
TP-372 Removed adaptive buffer size, added more stats

### DIFF
--- a/fftools/ffmpeg.c
+++ b/fftools/ffmpeg.c
@@ -1752,7 +1752,7 @@ static void print_report(int is_last_report, int64_t timer_start, int64_t cur_ti
     static float prev_transcode_pf = 0.0;
     static int64_t prev_transcode_max = 0;
 
-    if(transcode_us>0) {
+    if(transcode_us > 0) {
         transcode_total += transcode_us;
         transcode_max = transcode_us > transcode_max ? transcode_us : transcode_max;
         transcode_us_last = transcode_us;
@@ -1866,7 +1866,7 @@ static void print_report(int is_last_report, int64_t timer_start, int64_t cur_ti
             }
             avg_transcode_pf = frame_number > 0 ? transcode_total / frame_number / 1000.0 : -1.0;
             
-            av_bprintf(&buf, "frame=%5d avgfps=%3.*f fps=%3.*f q=%3.1f avgtranscode=%3.1f transcode=%3.1f transcode_max=%3.1f",
+            av_bprintf(&buf, "frame=%5d avgfps=%3.*f fps=%3.*f q=%3.1f avgtranscode=%3.1f transcode=%3.1f transcode_max=%3.1f ",
                      frame_number, fps < 9.95, fps, cur_fps < 9.95, cur_fps, q, avg_transcode_pf, cur_transcode_pf, cur_transcode_max / 1000.0);
 #else
             frame_number = ost->frame_number;
@@ -5107,7 +5107,7 @@ static int transcode(void)
     /* dump report by using the first video and audio streams */
 /*Proximie*/
 #if 1
-    print_report(1, timer_start, av_gettime_relative(),0);
+    print_report(1, timer_start, av_gettime_relative(), 0);
 #else
     print_report(1, timer_start, av_gettime_relative());
 #endif

--- a/fftools/ffmpeg.c
+++ b/fftools/ffmpeg.c
@@ -4972,8 +4972,6 @@ static void px_process(int64_t cur_time)
                     enc_ctx->bit_rate = bitrate;
                     enc_ctx->rc_max_rate = bitrate;
                     enc_ctx->rc_min_rate = bitrate;
-                    enc_ctx->rc_buffer_size = bitrate / 2; /* translates to 500ms */
-                    enc_ctx->rc_initial_buffer_occupancy = enc_ctx->rc_buffer_size / 2; /* translates to 250ms */
                     enc_ctx->bit_rate_tolerance = bitrate / 20; /* 5% under/overshoot */
                     
                     of = output_files[enc_ost->file_index];

--- a/fftools/ffmpeg.h
+++ b/fftools/ffmpeg.h
@@ -471,8 +471,10 @@ typedef struct OutputStream {
 
     /*Proximie*/
     int64_t fps_reset_time; /* time fps was reset */
+    int reset_frame_number; /* frame number when fps stats were reset */
     int total_frames;       /* count of frames since stream start vs frame_number that gets reset with variable frame rate changes */
     float prev_fps;         /* last valid fps value */
+    int need_transcode_reset; /* tells if we need to reset transcoding timing stats */
     /*End Proximie*/
 
     AVBSFContext            *bsf_ctx;


### PR DESCRIPTION
Added transcoding total average (since stream beginning) and current average/max (since last fps/bitrare change or 60s whicever is less) 

Also removed encoder adaptive buffer settings and instead keeping default - this is to alieviate potentail problem on low end of the bitrates when buffer becomes very small. 